### PR TITLE
Add version pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-oauth2
-flask
-requests_oauthlib
+oauth2==1.9.0.post1
+flask==1.1.1
+requests_oauthlib==1.1.0
 argparse


### PR DESCRIPTION
The code in `test_client.py` only works with `requests_oauthlib <= 1.1.0`, thus add version pins
(except for argparse, which is part of the standard lib since python 3.2)